### PR TITLE
ci: re-enable vector numba test in python 3.14t

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,7 +210,7 @@ jobs:
         id: test-vector
         run: |
           cd repo-vector
-          if uv run --project .. pytest -vv -rs tests --ignore tests/test_notebooks.py --benchmark-disable -n 4 --timeout=1000 ${{ matrix.python-version == '3.14t' && '--deselect tests/backends/test_numba_object.py::test_VectorObjectType' || '' }}; then
+          if uv run --project .. pytest -vv -rs tests --ignore tests/test_notebooks.py --benchmark-disable -n 4 --timeout=1000; then
             echo "success=true" >> $GITHUB_OUTPUT
           else
             echo "success=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
With https://github.com/scikit-hep/vector/pull/696, this test should now pass again with 3.14t