### PR TITLE
ci: test fsspec-xrootd dependency in Uproot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
       - name: Build uproot
         run: |
           cd repo-uproot5
-          uv pip install . --group=dev
+          uv pip install . --group=dev ${{ runner.os != 'Windows' && !contains(matrix.python-version, 't') && '--group=test-xrootd' || '' }}
 
       - name: Build vector
         run: |


### PR DESCRIPTION
The `fsspec-xrootd` dependency was moved out of the standard `test` dependency group since it started requiring the `xrootd` package. This PR adds it back if the runner is not Windows and when not using freethreaded Python. 