### PR TITLE
ci: add a ci that runs without any dask related dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -375,12 +375,12 @@ jobs:
       - name: Build uproot
         run: |
           cd repo-uproot5
-          uv pip install . --group=dev
+          uv pip install . --group=test
 
       - name: Build vector
         run: |
           cd repo-vector
-          uv pip install . --group=dev --group=test-all
+          uv pip install . --group=dev
 
       - name: Build boost-histogram
         run: |
@@ -402,6 +402,13 @@ jobs:
 
       - name: Show all versions
         run: uv pip list
+
+      - name: Ensure dask is not installed yet
+        run: |
+          if uv pip list --format=freeze | grep -iE '^(dask|dask-awkward|dask-histogram|distributed|bokeh)=='; then
+            echo "::error::dask-related package found before the explicit coffea dask install step"
+            exit 1
+          fi
 
       - name: Test scikit-hep/awkward
         id: test-awkward
@@ -457,7 +464,7 @@ jobs:
         id: test-coffea
         run: |
           cd repo-coffea
-          if uv run --project .. pytest -vv -rs tests --deselect=test_taskvine --benchmark-disable -m "not dask_client" -n 4 --timeout=1000 && uv run --project .. pytest -vv -rs tests --deselect=test_taskvine --benchmark-disable -m "dask_client" --timeout=1000; then
+          if uv run --project .. pytest -vv -rs tests --deselect=test_taskvine --benchmark-disable -m "not dask_client" -n 4 --timeout=1000; then
             echo "success=true" >> $GITHUB_OUTPUT
           else
             echo "success=false" >> $GITHUB_OUTPUT
@@ -475,7 +482,7 @@ jobs:
         id: test-coffea-dask
         run: |
           cd repo-coffea
-          if uv run --project .. pytest -vv -rs tests --deselect=test_taskvine --benchmark-disable -m "not dask_client" -n 4 --timeout=1000 && uv run --project .. pytest -vv -rs tests --deselect=test_taskvine --benchmark-disable -m "dask_client" --timeout=1000; then
+          if uv run --project .. pytest -vv -rs tests --deselect=test_taskvine --benchmark-disable -m "not dask_client" -n 4 --timeout=1000; then
             echo "success=true" >> $GITHUB_OUTPUT
           else
             echo "success=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,7 @@ jobs:
       - name: Build coffea
         run: |
           cd repo-coffea
-          uv pip install '.[dev,dask]'
+          uv pip install '.[dev,dask,dask-awkward]'
 
       - name: Add xdist
         run: uv pip install pytest-xdist
@@ -286,18 +286,249 @@ jobs:
           ${{ (steps.test-awkward.outputs.success == 'true' && steps.test-dask-awkward.outputs.success == 'true' && steps.test-uproot.outputs.success == 'true' && steps.test-vector.outputs.success == 'true' && steps.test-boost-histogram.outputs.success == 'true' && steps.test-hist.outputs.success == 'true' && steps.test-dask-histogram.outputs.success == 'true' && steps.test-coffea.outputs.success == 'true') && 'true' || 'false' }}
 
 
+  test-without-dask:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash
+
+    name: Test without dask (ubuntu-latest) - 🐍 3.14
+
+    env:
+      FILENAME: without-dask-results.md
+
+    steps:
+      - name: Set up Python 3.14
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.0.0
+        with:
+          enable-cache: false
+
+      - name: Sync env
+        run: |
+          git lfs install --skip-smudge
+          uv sync
+
+      - name: Clone scikit-hep/awkward
+        uses: actions/checkout@v4
+        with:
+          repository: scikit-hep/awkward
+          path: repo-awkward
+          submodules: true
+          ref: "main"
+          fetch-depth: 0
+
+      - name: Clone scikit-hep/uproot5
+        uses: actions/checkout@v4
+        with:
+          repository: scikit-hep/uproot5
+          path: repo-uproot5
+          ref: "main"
+          fetch-depth: 0
+
+      - name: Clone scikit-hep/vector
+        uses: actions/checkout@v4
+        with:
+          repository: scikit-hep/vector
+          path: repo-vector
+          ref: "main"
+          fetch-depth: 0
+
+      - name: Clone scikit-hep/boost-histogram
+        uses: actions/checkout@v4
+        with:
+          repository: scikit-hep/boost-histogram
+          path: repo-boost-histogram
+          submodules: true
+          ref: "develop"
+          fetch-depth: 0
+
+      - name: Clone scikit-hep/hist
+        uses: actions/checkout@v4
+        with:
+          repository: scikit-hep/hist
+          path: repo-hist
+          ref: "main"
+          fetch-depth: 0
+
+      - name: Clone scikit-hep/coffea
+        uses: actions/checkout@v4
+        with:
+          repository: scikit-hep/coffea
+          path: repo-coffea
+          ref: "master"
+          fetch-depth: 0
+
+      - name: Build awkward-cpp and awkward
+        run: |
+          cd repo-awkward
+          uvx nox -s prepare -- --headers --signatures --tests
+          uv pip install -vv . ./awkward-cpp -r requirements-test-full.txt -r requirements-test-ml.txt
+
+      - name: Build uproot
+        run: |
+          cd repo-uproot5
+          uv pip install . --group=dev
+
+      - name: Build vector
+        run: |
+          cd repo-vector
+          uv pip install . --group=dev --group=test-all
+
+      - name: Build boost-histogram
+        run: |
+          cd repo-boost-histogram
+          uv pip install -v . --group=test
+
+      - name: Build hist
+        run: |
+          cd repo-hist
+          uv pip install . --group=test
+
+      - name: Build coffea
+        run: |
+          cd repo-coffea
+          uv pip install '.[dev]'
+
+      - name: Add xdist
+        run: uv pip install pytest-xdist
+
+      - name: Show all versions
+        run: uv pip list
+
+      - name: Test scikit-hep/awkward
+        id: test-awkward
+        run: |
+          cd repo-awkward
+          if uv run --project .. pytest -vv -rs tests --benchmark-disable -n 4 --timeout=1000; then
+            echo "success=true" >> $GITHUB_OUTPUT
+          else
+            echo "success=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Test scikit-hep/uproot5
+        id: test-uproot
+        run: |
+          cd repo-uproot5
+          if uv run --project .. pytest -vv -rs tests --reruns 10 --reruns-delay 30 --only-rerun "(?i)http|ssl|timeout|expired|connection|socket" --timeout=1000; then
+            echo "success=true" >> $GITHUB_OUTPUT
+          else
+            echo "success=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Test scikit-hep/vector
+        id: test-vector
+        run: |
+          cd repo-vector
+          if uv run --project .. pytest -vv -rs tests --ignore tests/test_notebooks.py --benchmark-disable -n 4 --timeout=1000; then
+            echo "success=true" >> $GITHUB_OUTPUT
+          else
+            echo "success=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Test scikit-hep/boost-histogram
+        id: test-boost-histogram
+        run: |
+          cd repo-boost-histogram
+          if uv run --project .. pytest -vv -rs tests --timeout=1000; then
+            echo "success=true" >> $GITHUB_OUTPUT
+          else
+            echo "success=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Test scikit-hep/hist
+        id: test-hist
+        run: |
+          cd repo-hist
+          if uv run --project .. pytest -vv -rs tests --timeout=1000; then
+            echo "success=true" >> $GITHUB_OUTPUT
+          else
+            echo "success=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Test scikit-hep/coffea
+        id: test-coffea
+        run: |
+          cd repo-coffea
+          if uv run --project .. pytest -vv -rs tests --deselect=test_taskvine --benchmark-disable -m "not dask_client" -n 4 --timeout=1000 && uv run --project .. pytest -vv -rs tests --deselect=test_taskvine --benchmark-disable -m "dask_client" --timeout=1000; then
+            echo "success=true" >> $GITHUB_OUTPUT
+          else
+            echo "success=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build coffea dask extras
+        run: |
+          cd repo-coffea
+          uv pip install '.[dask]'
+
+      - name: Show all versions
+        run: uv pip list
+
+      - name: Test scikit-hep/coffea with dask
+        id: test-coffea-dask
+        run: |
+          cd repo-coffea
+          if uv run --project .. pytest -vv -rs tests --deselect=test_taskvine --benchmark-disable -m "not dask_client" -n 4 --timeout=1000 && uv run --project .. pytest -vv -rs tests --deselect=test_taskvine --benchmark-disable -m "dask_client" --timeout=1000; then
+            echo "success=true" >> $GITHUB_OUTPUT
+          else
+            echo "success=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Save results to file
+        run: |
+          echo -n "| without dask, ubuntu-latest, Python3.14 | " > $FILENAME
+          echo -n "${{ steps.test-awkward.outputs.success == 'true' && '✅' || '❌' }} | " >> $FILENAME
+          echo -n "${{ steps.test-uproot.outputs.success == 'true' && '✅' || '❌' }} | " >> $FILENAME
+          echo -n "${{ steps.test-vector.outputs.success == 'true' && '✅' || '❌' }} | " >> $FILENAME
+          echo -n "${{ steps.test-boost-histogram.outputs.success == 'true' && '✅' || '❌' }} | " >> $FILENAME
+          echo -n "${{ steps.test-hist.outputs.success == 'true' && '✅' || '❌' }} | " >> $FILENAME
+          echo -n "${{ steps.test-coffea.outputs.success == 'true' && '✅' || '❌' }} | " >> $FILENAME
+          echo "${{ steps.test-coffea-dask.outputs.success == 'true' && '✅' || '❌' }} |" >> $FILENAME
+
+      - name: Upload results artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.FILENAME }}
+          path: ${{ env.FILENAME }}
+
+      - name: Check if tests failed
+        run: |
+          echo ${{ steps.test-awkward.outputs.success == 'true' && ' ' || 'Awkward tests failed' }}
+          echo ${{ steps.test-uproot.outputs.success == 'true' && ' ' || 'Uproot tests failed' }}
+          echo ${{ steps.test-vector.outputs.success == 'true' && ' ' || 'Vector tests failed' }}
+          echo ${{ steps.test-boost-histogram.outputs.success == 'true' && ' ' || 'Boost-Histogram tests failed' }}
+          echo ${{ steps.test-hist.outputs.success == 'true' && ' ' || 'Hist tests failed' }}
+          echo ${{ steps.test-coffea.outputs.success == 'true' && ' ' || 'Coffea tests failed' }}
+          echo ${{ steps.test-coffea-dask.outputs.success == 'true' && ' ' || 'Coffea with dask tests failed' }}
+          ${{ (steps.test-awkward.outputs.success == 'true' && steps.test-uproot.outputs.success == 'true' && steps.test-vector.outputs.success == 'true' && steps.test-boost-histogram.outputs.success == 'true' && steps.test-hist.outputs.success == 'true' && steps.test-coffea.outputs.success == 'true' && steps.test-coffea-dask.outputs.success == 'true') && 'true' || 'false' }}
+
+
   summary:
     name: Collect results
     runs-on: ubuntu-latest
-    needs: test
+    needs: [test, test-without-dask]
     if: always()
 
     steps:
-      - name: Download all artifacts
+      - name: Download matrix artifacts
         uses: actions/download-artifact@v4
         with:
+          pattern: results-*.md
           merge-multiple: true
           path: results
+
+      - name: Download without-dask artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: without-dask-results.md
+          path: results-without-dask
 
       - name: Generate final summary
         run: |
@@ -305,4 +536,9 @@ jobs:
           echo "| System Configuration | Awkward | Dask-Awkward | Uproot | Vector | Boost-Histogram | Hist | Dask-Histogram | Coffea |" >> final_results.md
           echo "| --- | --- | --- | --- | --- | --- | --- | --- | --- |" >> final_results.md
           cat results/*.md >> final_results.md
+          echo "" >> final_results.md
+          echo "All packages tested without dask, dask-awkward and dask-histogram installed; coffea tested again after installing only dask and distributed." >> final_results.md
+          echo "| System Configuration | Awkward | Uproot | Vector | Boost-Histogram | Hist | Coffea (no dask) | Coffea (dask, no dask-awkward) |" >> final_results.md
+          echo "| --- | --- | --- | --- | --- | --- | --- | --- |" >> final_results.md
+          cat results-without-dask/*.md >> final_results.md
           cat final_results.md > $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Since dask related dependencies are now optional in coffea main branch, I'm adding a ci that tests all the packages without installing any dask related dependencies. Of course this CI skips dask-awkward and dask-histogram naturally. Then we only install dask and distributed (no dask-awkward/histogram) and run the coffea tests once more.